### PR TITLE
REPLICATED: Add HAVE_UNISTD_H to CMake and config.h.in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ ck_check_include_file("string.h" HAVE_STRING_H)
 ck_check_include_file("strings.h" HAVE_STRINGS_H)
 ck_check_include_file("sys/time.h" HAVE_SYS_TIME_H)
 ck_check_include_file("time.h" HAVE_TIME_H)
+ck_check_include_file("unistd.h" HAVE_UNISTD_H)
 
 ###############################################################################
 # Check functions

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -300,6 +300,9 @@ typedef uint64_t uintmax_t;
 /* Define to 1 if you have the <time.h> header file. */
 #cmakedefine HAVE_TIME_H 1
 
+/* Define to 1 if you have the <unistd.h> header file. */
+#cmakedefine HAVE_UNISTD_H 1
+
 /* Define to 1 if the system has the type `unsigned long long'. */
 #cmakedefine HAVE_UNSIGNED_LONG_LONG 1
 


### PR DESCRIPTION
Hi,
Thank you for maintaining CivetWeb repository - it's really awesome!

I've faced with issue recently: when I was trying to use `civetweb` in my pet-project  and build it with `clang` (16 version) I got and compilation error related to `check-unit-test-framework`  targets. The error is:

```
check/src/check.c:393:9: error: call to undeclared library function '_exit' with type 'void (int) __attribute__((noreturn))'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        _exit(1);
        ^
```

Having my investigation done, I found that this is related to `libcheck/lib` which you are using as c-unit-test framework in `civetweb` and has its own fork as `civetweb/check`. Also I found that this issue was fixed in upstream in commit 
https://github.com/libcheck/check/commit/f63378cd2e2e9330860406305f8e8f2bccf489f9

This my PR just reflect that changes from the upstream commit. As I'm not sure about rebasing this fork up to the latest version of upstream repository, therefore I've made this PR with this particular change.

I wonder if anyone could take a look and merge it or just rebase this fork to the latest version. Thanks